### PR TITLE
Fix Argument Exception on schema

### DIFF
--- a/Raml.WebApiExplorer/RAML.WebApiExplorer.Tests/RAML.WebApiExplorer.Tests.csproj
+++ b/Raml.WebApiExplorer/RAML.WebApiExplorer.Tests/RAML.WebApiExplorer.Tests.csproj
@@ -80,6 +80,7 @@
     <Compile Include="Types\StoragediskUUID.cs" />
     <Compile Include="Types\Storagenfs.cs" />
     <Compile Include="Types\Storagetmpfs.cs" />
+    <Compile Include="Types\WebLocation.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Raml.WebApiExplorer/RAML.WebApiExplorer.Tests/SchemaBuilderTests.cs
+++ b/Raml.WebApiExplorer/RAML.WebApiExplorer.Tests/SchemaBuilderTests.cs
@@ -22,6 +22,14 @@ namespace RAML.WebApiExplorer.Tests
 		}
 
 		[Test]
+		public void ShouldParseTypeWithNestedTypeWhereFirstTypeHasNoSettableProperties() {
+			var schema = schemaBuilder.Get(typeof(WebLocation));
+			Assert.IsTrue(schema.Contains("\"Location\":"));
+			var obj = JsonSchema.Parse(schema);
+			Assert.IsNotNull(obj);
+		}
+
+		[Test]
 		public void ShouldParseArray()
 		{
 			var schema = schemaBuilder.Get(typeof(Owner[]));

--- a/Raml.WebApiExplorer/RAML.WebApiExplorer.Tests/Types/WebLocation.cs
+++ b/Raml.WebApiExplorer/RAML.WebApiExplorer.Tests/Types/WebLocation.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace RAML.WebApiExplorer.Tests.Types {
+	public class WebLocation 
+	{
+		public Uri BaseUri { get; set; }
+		public string Location { get; set; }
+	}
+}

--- a/Raml.WebApiExplorer/RAML.WebApiExplorer/SchemaBuilder.cs
+++ b/Raml.WebApiExplorer/RAML.WebApiExplorer/SchemaBuilder.cs
@@ -288,7 +288,7 @@ namespace RAML.WebApiExplorer
 	                schema += GetOneOfProperty(prop, subclasses, pad);
 	        }
 
-	        if (prop != props.Last())
+	        if (prop != props.Last() && !String.IsNullOrWhiteSpace(schema))
 	            schema = schema.Substring(0, schema.Length - "\r\n".Length) + ",\r\n";
 
 	        return schema;


### PR DESCRIPTION
Fix exception as described in #21. The problem was attempting to SubString an empty string. This was caused by a Type with multiple properties where the first property is Complex but doesn't have settable properties.